### PR TITLE
「一覧に戻る」ボタンを押すと404になる問題を修正する

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,7 @@
         <div class="singleButtonWrapper">
           <div class="button_wrapper" id="singleButtonWrapper"></div>
           <div class="content">
-            <p><a href="/ohamaru-button/">一覧に戻る</a></p>
+            <p><a href="/nazupi-button/">一覧に戻る</a></p>
           </div>
         </div>
         <div class="multiButtonWrapper">


### PR DESCRIPTION
「このボタンへのリンク」を押した後に表示される「一覧に戻る」ボタンを押すと404になることに気付いたので修正です。
`/ohamaru-button/` へのリンクになっていたものを `/nazupi-button/` へのリンクにしています。